### PR TITLE
Add indentation argument for oc_to_string

### DIFF
--- a/moses/comboreduct/combo/vertex.cc
+++ b/moses/comboreduct/combo/vertex.cc
@@ -271,7 +271,7 @@ void copy_without_null_vertices(combo_tree::iterator src,
 
 }
 
-std::string oc_to_string(combo::combo_tree &ct)
+std::string oc_to_string(combo::combo_tree &ct, const std::string& /*indent*/)
 {
 	std::ostringstream os;
 	combo::ostream_combo_tree(os, ct);
@@ -280,7 +280,7 @@ std::string oc_to_string(combo::combo_tree &ct)
 	return str;
 }
 
-std::string oc_to_string(combo::vertex &v)
+std::string oc_to_string(combo::vertex &v, const std::string& /*indent*/)
 {
 	std::ostringstream os;
 	combo::ostream_vertex(os, v);

--- a/moses/comboreduct/combo/vertex.h
+++ b/moses/comboreduct/combo/vertex.h
@@ -32,6 +32,7 @@
 #include <opencog/util/numeric.h>
 #include <opencog/util/exceptions.h>
 #include <opencog/util/oc_assert.h>
+#include <opencog/util/empty_string.h>
 
 #include <moses/comboreduct/combo/action.h>
 #include <moses/comboreduct/combo/action_symbol.h>
@@ -801,19 +802,23 @@ inline bool may_have_side_effects(combo_tree::iterator /*it*/)
  * Used only during GDB debugging
  *
  * @param  combo_tree the combo tree to be printed
+ * @param  indent indentation string preprending each line
  *
  * @return string representation of the combo_tree
  */
-std::string oc_to_string(combo::combo_tree&);
+std::string oc_to_string(combo::combo_tree&,
+                         const std::string& indent=empty_string);
 
 /** Printing utility
  * Used only during GDB debugging
  *
  * @param  vertex the vertex to be printed
+ * @param  indent indentation string preprending each line
  *
  * @return string representation of the vertex
  */
-std::string oc_to_string(combo::vertex&);
+std::string oc_to_string(combo::vertex&,
+                         const std::string& indent=empty_string);
 
 } // ~namespace opencog
 


### PR DESCRIPTION
As per http://wiki.opencog.org/w/Development_standards#Pretty_Print_OpenCog_Objects recent changes.